### PR TITLE
perf(my-list): cache artwork on disk and stop full re-fetch after add-history

### DIFF
--- a/lib/data/register_notifier.dart
+++ b/lib/data/register_notifier.dart
@@ -36,10 +36,27 @@ class DataList extends AsyncNotifier<List<UserSong>> {
   }
 
   Future<void> addHistory(String userSongId, double score, String? memo, {DateTime? sungAt}) async {
-    await KaraokeApiService.instance.addHistory(userSongId, score, memo, sungAt: sungAt);
-    // Reload to get updated history
-    final songs = await KaraokeApiService.instance.getUserSongs();
-    state = AsyncData(songs);
+    final created = await KaraokeApiService.instance.addHistory(
+      userSongId, score, memo, sungAt: sungAt);
+    // Patch the existing song's history in-place (newest-first) instead of
+    // re-fetching the whole list — keeps the My List view snappy after singing.
+    final current = state.value;
+    if (current == null) return;
+    state = AsyncData([
+      for (final s in current)
+        if (s.id == userSongId)
+          UserSong(
+            id: s.id,
+            song: s.song,
+            key: s.key,
+            season: s.season,
+            tags: s.tags,
+            createdAt: s.createdAt,
+            history: [created, ...s.history],
+          )
+        else
+          s,
+    ]);
   }
 
   void reload() {

--- a/lib/pages/my_list_page.dart
+++ b/lib/pages/my_list_page.dart
@@ -1,3 +1,4 @@
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:untitled/data/drop_down_notifier.dart';
@@ -189,7 +190,6 @@ class MyListPageState extends ConsumerState<MyListPage> {
                 }
 
                 return ListView.builder(
-                  shrinkWrap: true,
                   itemCount: data.length,
                   itemBuilder: (context, index) {
                     if (index >= data.length) {
@@ -224,11 +224,25 @@ class MyListPageState extends ConsumerState<MyListPage> {
                                 children: [
                                   ClipRRect(
                                     borderRadius: BorderRadius.circular(6),
-                                    child: Image.network(
-                                      song.song.artworkUrl(52),
+                                    child: CachedNetworkImage(
+                                      imageUrl: song.song.artworkUrl(52),
                                       width: 52,
                                       height: 52,
                                       fit: BoxFit.cover,
+                                      memCacheWidth: 156, // ~3x for retina
+                                      fadeInDuration: const Duration(milliseconds: 120),
+                                      placeholder: (_, __) => Container(
+                                        width: 52,
+                                        height: 52,
+                                        color: const Color(0xFFF5F5F5),
+                                      ),
+                                      errorWidget: (_, __, ___) => Container(
+                                        width: 52,
+                                        height: 52,
+                                        color: const Color(0xFFF5F5F5),
+                                        child: const Icon(Icons.music_note,
+                                            size: 20, color: Color(0xFFBDBDBD)),
+                                      ),
                                     ),
                                   ),
                                   const SizedBox(width: 12),

--- a/lib/pages/my_song_page.dart
+++ b/lib/pages/my_song_page.dart
@@ -1,3 +1,4 @@
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart';
 import 'package:untitled/pages/list_edit_page.dart';
@@ -85,9 +86,21 @@ class MySongPageState extends ConsumerState<MySongPage> {
                     children: [
                       ClipRRect(
                         borderRadius: BorderRadius.circular(10),
-                        child: Image.network(
-                          song.song.artworkUrl(80),
+                        child: CachedNetworkImage(
+                          imageUrl: song.song.artworkUrl(80),
                           width: 72, height: 72, fit: BoxFit.cover,
+                          memCacheWidth: 216,
+                          fadeInDuration: const Duration(milliseconds: 120),
+                          placeholder: (_, __) => Container(
+                            width: 72, height: 72,
+                            color: const Color(0xFFF5F5F5),
+                          ),
+                          errorWidget: (_, __, ___) => Container(
+                            width: 72, height: 72,
+                            color: const Color(0xFFF5F5F5),
+                            child: const Icon(Icons.music_note,
+                                size: 24, color: Color(0xFFBDBDBD)),
+                          ),
                         ),
                       ),
                       const SizedBox(width: 14),

--- a/lib/services/api_service.dart
+++ b/lib/services/api_service.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'dart:io';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:http/http.dart' as http;
+import '../models/singing_history_item.dart';
 import '../models/song.dart';
 import '../models/user_song.dart';
 
@@ -113,7 +114,7 @@ class KaraokeApiService {
     return data.map((e) => Song.fromBackendJson(e as Map<String, dynamic>)).toList();
   }
 
-  Future<void> addHistory(String userSongId, double score, String? memo, {DateTime? sungAt}) async {
+  Future<SingingHistoryItem> addHistory(String userSongId, double score, String? memo, {DateTime? sungAt}) async {
     final body = <String, dynamic>{'score': score};
     if (memo != null && memo.isNotEmpty) body['memo'] = memo;
     if (sungAt != null) body['sung_at'] = sungAt.toIso8601String();
@@ -125,5 +126,7 @@ class KaraokeApiService {
     if (resp.statusCode != 201) {
       throw Exception('Failed to add history: ${resp.statusCode}');
     }
+    return SingingHistoryItem.fromJson(
+        json.decode(utf8.decode(resp.bodyBytes)) as Map<String, dynamic>);
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -38,6 +38,7 @@ dependencies:
   flutter_native_splash: ^2.3.1
   http: ^1.1.0
   shared_preferences: ^2.2.0
+  cached_network_image: ^3.4.1
   video_player: ^2.7.0
   riverpod: ^3.2.1
   flutter_riverpod: ^3.3.1


### PR DESCRIPTION
## Why

The My List screen felt slow because:

1. `Image.network` re-fetched all ~50 thumbnails from Apple's CDN on every cold start with no disk cache.
2. `DataList.addHistory` re-fetched the **entire** user-song list from the API after every singing log.

(See companion API PR yukik8/karaoke-api#1 for the bigger backend N+1 fix.)

## Changes

- **Add `cached_network_image: ^3.4.1`** dependency.
- **`pages/my_list_page` + `pages/my_song_page`** — replace `Image.network` with `CachedNetworkImage` (disk cache + placeholder + `memCacheWidth` tuned for retina); second launch shows the list instantly. Also dropped a redundant `shrinkWrap: true` on the inner `ListView.builder`.
- **`services/api_service.addHistory`** — return the created `SingingHistoryItem` (the endpoint already returns it).
- **`data/register_notifier.addHistory`** — patch the affected `UserSong` in-place with the new history item instead of refetching the whole list. Keeps My List snappy after singing.

## Manual steps after merge

`flutter pub get` to pull in `cached_network_image`.